### PR TITLE
Switch to solders Pubkey for Solana public key handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ import time
 from typing import Any, Dict, Optional
 
 from dexscreener import DexscreenerClient
-from solana.publickey import PublicKey
+from solders.pubkey import Pubkey as PublicKey
 from solana.rpc.async_api import AsyncClient
 from openai import AsyncOpenAI
 
@@ -100,7 +100,7 @@ class RugRiskMonitor:
         """Fetch freeze/mint authorities from Solana RPC."""
         try:
             resp = await self.rpc_client.get_account_info(
-                PublicKey(self.token_address), encoding="jsonParsed"
+                PublicKey.from_string(self.token_address), encoding="jsonParsed"
             )
             info = resp.get("result", {}).get("value")
             if info and info.get("data"):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ requests>=2.31.0
 aiohttp>=3.9.5
 setuptools>=61.0
 solana>=0.30.2
+solders>=0.26.0
 openai>=1.14.3


### PR DESCRIPTION
## Summary
- replace deprecated `solana.publickey.PublicKey` import with `solders.pubkey.Pubkey`
- convert token addresses using `PublicKey.from_string`
- add direct `solders` dependency

## Testing
- `python -m py_compile main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893e16d04bc832b9b4f1a8664c839e5