### PR TITLE
Handle SerdeJSONError import for newer solders releases

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,7 +16,11 @@ from typing import Any, Dict, Optional
 
 from dexscreener import DexscreenerClient
 from solders.pubkey import Pubkey as PublicKey
-from solders import SerdeJSONError
+try:
+    # SerdeJSONError moved under solders.errors in newer versions
+    from solders.errors import SerdeJSONError
+except ImportError:  # pragma: no cover - fallback for older versions
+    from solders import SerdeJSONError  # type: ignore[attr-defined]
 from solana.rpc.async_api import AsyncClient
 from openai import AsyncOpenAI
 


### PR DESCRIPTION
## Summary
- make SerdeJSONError import compatible with solders>=0.20

## Testing
- `python -m py_compile main.py`
- `pytest`
- `timeout 5 python main.py 11111111111111111111111111111111` *(fails: Cannot connect to host api.dexscreener.com)*

------
https://chatgpt.com/codex/tasks/task_e_6893e8c3f190832b9516a6c57c5a0ec0