### PR TITLE
Retry on malformed RPC

### DIFF
--- a/tests/test_onchain_retry.py
+++ b/tests/test_onchain_retry.py
@@ -1,0 +1,30 @@
+import asyncio
+import pathlib
+import sys
+
+from solders.errors import SerdeJSONError
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from main import RugRiskMonitor
+
+
+class FailingClient:
+    async def get_account_info(self, *args, **kwargs):
+        raise SerdeJSONError("bad json")
+
+
+def test_onchain_stops_after_consecutive_errors(monkeypatch):
+    monitor = RugRiskMonitor(
+        "solana",
+        "pair",
+        "So11111111111111111111111111111111111111112",
+        "amm",
+    )
+    monkeypatch.setattr(monitor, "rpc_client", FailingClient())
+
+    async def run():
+        for _ in range(3):
+            await monitor.fetch_onchain_data()
+
+    asyncio.run(run())
+    assert monitor._onchain_error is True


### PR DESCRIPTION
## Summary
- handle transient Solana RPC JSON errors with retry logic instead of immediate shutdown
- cover consecutive on-chain error handling with a unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893ee861c84832bbb3cba04c324b0af