### PR TITLE
Reduce analysis loop to 1s

### DIFF
--- a/main.py
+++ b/main.py
@@ -304,10 +304,14 @@ class RugRiskMonitor:
             await asyncio.sleep(5)
 
     async def _llm_loop(self) -> None:
+        """Periodically compute metrics and output analysis."""
         while True:
+            if not self.price_history:
+                await asyncio.sleep(1)
+                continue
             self.compute_metrics()
             await self.send_to_llm()
-            await asyncio.sleep(30)
+            await asyncio.sleep(1)
 
     async def run(self) -> None:
         await asyncio.gather(


### PR DESCRIPTION
## Summary
- update monitoring loop to emit analytics every second once price data available

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893f2f52468832bb156b6982f26c552